### PR TITLE
feat: implementar base del servidor coordinador y comunicación con nodos

### DIFF
--- a/src/main/java/cc4p1/coordinator/CoordinatorServer.java
+++ b/src/main/java/cc4p1/coordinator/CoordinatorServer.java
@@ -1,0 +1,123 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package cc4p1.coordinator;
+
+/**
+ *
+ * @author Camila
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.Executors;
+
+public class CoordinatorServer {
+
+    private static final int PORT = 8080;
+    private static final int NUM_PARTITIONS = 6;
+    private static final RoutingTable routingTable = new RoutingTable(NUM_PARTITIONS);
+
+    public static void main(String[] args) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        server.createContext("/register", new RegisterHandler());
+        server.createContext("/consultar_cuenta", new ConsultarCuentaHandler());
+        server.createContext("/healthz", new HealthHandler());
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+
+        System.out.println("[Coordinator] Servidor iniciado en puerto " + PORT);
+    }
+
+    // --- Handlers ---
+
+    static class HealthHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String response = "{\"ok\":true,\"msg\":\"coordinator up\"}";
+            sendResponse(exchange, 200, response);
+        }
+    }
+
+    static class RegisterHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendResponse(exchange, 405, "{\"error\":\"Método no permitido\"}");
+                return;
+            }
+
+            Map<String, String> q = parseQuery(exchange.getRequestURI());
+            String host = q.get("host");
+            int port = Integer.parseInt(q.getOrDefault("port", "0"));
+            String role = q.getOrDefault("role", "replica");
+            List<Integer> parts = new ArrayList<>();
+            if (q.containsKey("partitions")) {
+                for (String s : q.get("partitions").split(",")) {
+                    parts.add(Integer.valueOf(s.trim()));
+                }
+            }
+
+            routingTable.registerNode(host, port, parts, role);
+            sendResponse(exchange, 200, "{\"ok\":true,\"msg\":\"nodo registrado\"}");
+        }
+    }
+
+    static class ConsultarCuentaHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendResponse(exchange, 405, "{\"error\":\"Método no permitido\"}");
+                return;
+            }
+
+            Map<String, String> q = parseQuery(exchange.getRequestURI());
+            int id = Integer.parseInt(q.getOrDefault("id", "-1"));
+            int partition = Math.floorMod(id, NUM_PARTITIONS);
+            List<NodeInfo> replicas = routingTable.getReplicas(partition);
+
+            if (replicas.isEmpty()) {
+                sendResponse(exchange, 503, "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}");
+                return;
+            }
+
+            // Esto lo implementaremos luego
+            String body = WorkerForwarder.forwardQuery(replicas, id);
+            sendResponse(exchange, 200, body);
+        }
+    }
+
+    static void sendResponse(HttpExchange ex, int code, String body) throws IOException {
+        ex.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        ex.sendResponseHeaders(code, body.getBytes().length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(body.getBytes());
+        }
+    }
+
+    static Map<String, String> parseQuery(URI uri) {
+        Map<String, String> map = new HashMap<>();
+        String query = uri.getRawQuery();
+        if (query == null) return map;
+        for (String pair : query.split("&")) {
+            int idx = pair.indexOf("=");
+            if (idx > 0) {
+                map.put(
+                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8)
+                );
+            }
+        }
+        return map;
+    }
+}

--- a/src/main/java/cc4p1/coordinator/NodeInfo.java
+++ b/src/main/java/cc4p1/coordinator/NodeInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package cc4p1.coordinator;
+
+/**
+ *
+ * @author Camila
+ */
+public class NodeInfo {
+    private final String host;
+    private final int port;
+    private final int priority;
+    
+    public NodeInfo(String host, int port, int priority) {
+        this.host = host;
+        this.port = port;
+        this.priority = priority;
+    }
+    
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public String toString() {
+        return host + ":" + port + "(p=" + priority + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NodeInfo)) return false;
+        NodeInfo node = (NodeInfo) o;
+        return port == node.port && host.equals(node.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return host.hashCode() * 31 + port;
+    }
+    
+}

--- a/src/main/java/cc4p1/coordinator/RoutingTable.java
+++ b/src/main/java/cc4p1/coordinator/RoutingTable.java
@@ -1,0 +1,57 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package cc4p1.coordinator;
+
+import java.util.*;
+
+/**
+ *
+ * @author Camila
+ */
+public class RoutingTable {
+    private final int numPartitions;
+    private final Map<Integer, List<NodeInfo>> table;
+
+    public RoutingTable(int numPartitions) {
+        this.numPartitions = numPartitions;
+        this.table = new HashMap<>();
+        for (int i = 0; i < numPartitions; i++) {
+            table.put(i, new ArrayList<>());  
+        }
+    }
+    
+    public synchronized void registerNode(String host, int port, List<Integer> partitions, String role) {
+        int priority = "primary".equalsIgnoreCase(role) ? 0 : 1;
+
+        for (int part : partitions) {
+            if (!table.containsKey(part)) continue;
+
+            List<NodeInfo> replicas = table.get(part);
+
+            replicas.removeIf(n -> n.getHost().equals(host) && n.getPort() == port);
+
+            replicas.add(new NodeInfo(host, port, priority));
+            replicas.sort(Comparator.comparingInt(NodeInfo::getPriority));
+
+            System.out.printf("[RoutingTable] Partición %d → %s%n", part, replicas);
+        }
+    }
+    
+    public synchronized List<NodeInfo> getReplicas(int partition) {
+        return table.getOrDefault(partition, Collections.emptyList());
+    }
+    
+    public synchronized Map<Integer, List<NodeInfo>> snapshot() {
+        Map<Integer, List<NodeInfo>> copy = new HashMap<>();
+        for (var e : table.entrySet()) {
+            copy.put(e.getKey(), new ArrayList<>(e.getValue()));
+        }
+        return copy;
+    }
+    
+    public int getNumPartitions() {
+        return numPartitions;
+    }
+}

--- a/src/main/java/cc4p1/coordinator/WorkerForwarder.java
+++ b/src/main/java/cc4p1/coordinator/WorkerForwarder.java
@@ -1,0 +1,55 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package cc4p1.coordinator;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ *
+ * @author Camila
+ */
+public class WorkerForwarder {
+    private static final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofMillis(700))
+            .build(); 
+    
+     public static String forwardQuery(List<NodeInfo> replicas, int accountId) {
+        for (NodeInfo node : replicas) {
+            String url = String.format("http://%s:%d/consultar_cuenta?id=%d",
+                    node.getHost(), node.getPort(), accountId);
+
+            try {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .timeout(Duration.ofMillis(1300))
+                        .GET()
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                int code = response.statusCode();
+
+                
+                if (code == 200 || code == 404) {
+                    System.out.printf("[Forwarder] Nodo %s respondió %d%n", node, code);
+                    return response.body();
+                }
+
+                System.out.printf("[Forwarder] Nodo %s devolvió código %d%n", node, code);
+
+            } catch (IOException | InterruptedException e) {
+                System.out.printf("[Forwarder] Falló nodo %s (%s)%n", node, e.getClass().getSimpleName());
+            }
+        }
+
+        
+        return "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}";
+    }
+}


### PR DESCRIPTION
Se implementan las clases base del servidor coordinador (Sprint 1):
- NodeInfo.java: modelo de información de nodos (host, puerto, prioridad)
- RoutingTable.java: registro y gestión de particiones y réplicas
- WorkerForwarder.java: reenvío de consultas HTTP a nodos trabajadores
- CoordinatorServer.java: servidor principal con endpoints /register, /consultar_cuenta y /healthz

Permite registrar nodos, calcular particiones y ejecutar la query CONSULTAR_CUENTA
con reintentos automáticos ante fallos de réplica.