### PR TITLE
feat: implementar failover y tolerancia a fallos en coordinador 

### DIFF
--- a/src/main/java/cc4p1/coordinator/CoordinatorServer.java
+++ b/src/main/java/cc4p1/coordinator/CoordinatorServer.java
@@ -111,17 +111,34 @@ public class CoordinatorServer {
 
             Map<String, String> q = parseQuery(exchange.getRequestURI());
             String host = q.get("host");
-            int port = Integer.parseInt(q.getOrDefault("port", "0"));
-            String role = q.getOrDefault("role", "replica");
-            List<Integer> parts = new ArrayList<>();
-            if (q.containsKey("partitions")) {
-                for (String s : q.get("partitions").split(",")) {
+            String portStr = q.get("port");
+            String partitionsStr = q.get("partitions");
+            
+            // Validaciones
+            if (host == null || host.isBlank() || portStr == null || partitionsStr == null) {
+                sendResponse(exchange, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"Faltan parámetros: host, port, partitions\"}");
+                return;
+            }
+            
+            try {
+                int port = Integer.parseInt(portStr);
+                if (port <= 0 || port > 65535) {
+                    sendResponse(exchange, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"Puerto debe estar entre 1 y 65535\"}");
+                    return;
+                }
+                
+                String role = q.getOrDefault("role", "replica");
+                List<Integer> parts = new ArrayList<>();
+                for (String s : partitionsStr.split(",")) {
                     parts.add(Integer.valueOf(s.trim()));
                 }
-            }
 
-            routingTable.registerNode(host, port, parts, role);
-            sendResponse(exchange, 200, "{\"ok\":true,\"msg\":\"nodo registrado\"}");
+                routingTable.registerNode(host, port, parts, role);
+                sendResponse(exchange, 200, "{\"ok\":true,\"msg\":\"nodo registrado\"}");
+                
+            } catch (NumberFormatException e) {
+                sendResponse(exchange, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"Parámetros numéricos inválidos\"}");
+            }
         }
     }
 
@@ -137,23 +154,41 @@ public class CoordinatorServer {
             }
 
             Map<String, String> q = parseQuery(exchange.getRequestURI());
-            int id = Integer.parseInt(q.getOrDefault("id", "-1"));
-            int partition = PARTITIONER.partForId(id);
-            List<NodeInfo> replicas = routingTable.getReplicas(partition);
-
-            if (replicas.isEmpty()) {
+            String idStr = q.get("id");
+            
+            if (idStr == null) {
                 errorsTotal.incrementAndGet();
-                System.out.println("[Coordinator] No hay réplicas para la partición " + partition + ". Snapshot: "
-                        + routingTable.snapshot());
-                sendResponse(exchange, 503, "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}");
+                sendResponse(exchange, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"Falta parámetro id\"}");
                 return;
             }
+            
+            try {
+                int id = Integer.parseInt(idStr);
+                int partition = PARTITIONER.partForId(id);
+                List<NodeInfo> replicas = routingTable.getReplicas(partition);
 
-            String body = WorkerForwarder.forwardQuery(replicas, id);
-            long duration = System.currentTimeMillis() - start;
-            System.out.printf("[Coordinator] GET /consultar_cuenta?id=%d → partition=%d, duration=%dms%n",
-                    id, partition, duration);
-            sendResponse(exchange, 200, body);
+                if (replicas.isEmpty()) {
+                    errorsTotal.incrementAndGet();
+                    System.out.println("[Coordinator] No hay réplicas para la partición " + partition + ". Snapshot: "
+                            + routingTable.snapshot());
+                    sendResponse(exchange, 503, "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}");
+                    return;
+                }
+
+                WorkerForwarder.ForwardResult result = WorkerForwarder.forwardQueryWithMetrics(replicas, id);
+                if (result.usedFailover) {
+                    fallbacksTotal.incrementAndGet();
+                }
+                
+                long duration = System.currentTimeMillis() - start;
+                System.out.printf("[Coordinator] GET /consultar_cuenta?id=%d → partition=%d, duration=%dms, failover=%s%n",
+                        id, partition, duration, result.usedFailover);
+                sendResponse(exchange, 200, result.body);
+                
+            } catch (NumberFormatException e) {
+                errorsTotal.incrementAndGet();
+                sendResponse(exchange, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"Parámetro id inválido\"}");
+            }
         }
     }
 
@@ -204,23 +239,26 @@ public class CoordinatorServer {
                     return;
                 }
 
-                // Solo intentamos el primario (priority=0)
-                NodeInfo primary = replicas.get(0);
-                System.out.printf("[Coordinator] POST /transferir_cuenta txId=%s origen=%d destino=%d monto=%.2f → partition=%d, primary=%s%n",
-                        txId, origen, destino, monto, partition, primary);
+                System.out.printf("[Coordinator] POST /transferir_cuenta txId=%s origen=%d destino=%d monto=%.2f → partition=%d, réplicas=%d%n",
+                        txId, origen, destino, monto, partition, replicas.size());
 
-                String body = WorkerForwarder.forwardTransfer(primary, origen, destino, monto, txId);
+                // Usar failover inteligente: reintentar solo en fallos de red, no en errores de negocio
+                WorkerForwarder.ForwardResult result = WorkerForwarder.forwardTransferWithFailover(replicas, origen, destino, monto, txId);
+                if (result.usedFailover) {
+                    fallbacksTotal.incrementAndGet();
+                }
+                
                 long duration = System.currentTimeMillis() - start;
 
                 // Determinar código de respuesta basado en el body
-                int responseCode = determineResponseCode(body);
+                int responseCode = determineResponseCode(result.body);
                 if (responseCode >= 400) {
                     errorsTotal.incrementAndGet();
                 }
 
-                System.out.printf("[Coordinator] Transfer txId=%s completado con código %d en %dms%n",
-                        txId, responseCode, duration);
-                sendResponse(exchange, responseCode, body);
+                System.out.printf("[Coordinator] Transfer txId=%s completado con código %d en %dms, failover=%s%n",
+                        txId, responseCode, duration, result.usedFailover);
+                sendResponse(exchange, responseCode, result.body);
 
             } catch (NumberFormatException e) {
                 errorsTotal.incrementAndGet();
@@ -262,25 +300,24 @@ public class CoordinatorServer {
                     return;
                 }
 
-                System.out.printf("[Coordinator] GET /estado_prestamo?id=%d → partition=%d, replicas=%s%n",
-                        cuentaId, partition, replicas);
+                System.out.printf("[Coordinator] GET /estado_prestamo?id=%d → partition=%d, réplicas=%d%n",
+                        cuentaId, partition, replicas.size());
 
-                String body = WorkerForwarder.forwardPrestamo(replicas, cuentaId);
-                long duration = System.currentTimeMillis() - start;
-
-                // Contar fallbacks si se intentó más de un nodo
-                if (replicas.size() > 1 && body.contains("\"ok\":true")) {
+                WorkerForwarder.ForwardResult result = WorkerForwarder.forwardPrestamoWithMetrics(replicas, cuentaId);
+                if (result.usedFailover) {
                     fallbacksTotal.incrementAndGet();
                 }
+                
+                long duration = System.currentTimeMillis() - start;
 
-                int responseCode = determineResponseCode(body);
+                int responseCode = determineResponseCode(result.body);
                 if (responseCode >= 400) {
                     errorsTotal.incrementAndGet();
                 }
 
-                System.out.printf("[Coordinator] Prestamo id=%d completado con código %d en %dms%n",
-                        cuentaId, responseCode, duration);
-                sendResponse(exchange, responseCode, body);
+                System.out.printf("[Coordinator] Prestamo id=%d completado con código %d en %dms, failover=%s%n",
+                        cuentaId, responseCode, duration, result.usedFailover);
+                sendResponse(exchange, responseCode, result.body);
 
             } catch (NumberFormatException e) {
                 errorsTotal.incrementAndGet();

--- a/src/main/java/cc4p1/coordinator/WorkerForwarder.java
+++ b/src/main/java/cc4p1/coordinator/WorkerForwarder.java
@@ -28,8 +28,25 @@ public class WorkerForwarder {
             .connectTimeout(Duration.ofMillis(700))
             .build();
 
-    public static String forwardQuery(List<NodeInfo> replicas, int accountId) {
+    /**
+     * Resultado de una operación de forwarding con información de failover.
+     */
+    public static class ForwardResult {
+        public final String body;
+        public final boolean usedFailover;
+        public final int replicaIndex;
+        
+        public ForwardResult(String body, boolean usedFailover, int replicaIndex) {
+            this.body = body;
+            this.usedFailover = usedFailover;
+            this.replicaIndex = replicaIndex;
+        }
+    }
+
+    public static ForwardResult forwardQueryWithMetrics(List<NodeInfo> replicas, int accountId) {
         boolean any404 = false;
+        int replicaIndex = 0;
+        
         for (NodeInfo node : replicas) {
             String url = String.format("http://%s:%d/consultar_cuenta?id=%d",
                     node.getHost(), node.getPort(), accountId);
@@ -45,73 +62,137 @@ public class WorkerForwarder {
                 int code = response.statusCode();
 
                 if (code == 200) {
-                    System.out.printf("[Forwarder] Nodo %s respondió %d%n", node, code);
-                    return response.body();
+                    if (replicaIndex > 0) {
+                        System.out.printf("[Failover] ✓ Cuenta %d respondida por réplica %d (%s) tras fallo de primario%n",
+                                accountId, replicaIndex, node);
+                    } else {
+                        System.out.printf("[Forwarder] Nodo primario %s respondió %d%n", node, code);
+                    }
+                    return new ForwardResult(response.body(), replicaIndex > 0, replicaIndex);
                 }
 
                 if (code == 404) {
-                    // No existe en esta réplica, probar la siguiente
-                    System.out.printf("[Forwarder] Nodo %s respondió 404, probando siguiente%n", node);
+                    System.out.printf("[Forwarder] Nodo %s respondió 404, probando siguiente réplica%n", node);
                     any404 = true;
+                    replicaIndex++;
                     continue;
                 }
 
-                System.out.printf("[Forwarder] Nodo %s devolvió código %d%n", node, code);
+                // Errores 5xx: reintentar en siguiente réplica
+                if (code >= 500 && code < 600) {
+                    System.out.printf("[Failover] Nodo %s respondió %d (error servidor), probando siguiente réplica%n", node, code);
+                    replicaIndex++;
+                    continue;
+                }
+
+                System.out.printf("[Forwarder] Nodo %s devolvió código %d (no reintentar)%n", node, code);
+                return new ForwardResult(response.body(), replicaIndex > 0, replicaIndex);
 
             } catch (IOException | InterruptedException e) {
-                System.out.printf("[Forwarder] Falló nodo %s (%s)%n", node, e.getClass().getSimpleName());
+                System.out.printf("[Failover] Nodo %s falló (%s: %s), probando siguiente réplica%n",
+                        node, e.getClass().getSimpleName(), e.getMessage());
+                replicaIndex++;
             }
         }
 
-        // Si llegamos aquí, ninguna réplica respondió 200.
-        // Si al menos una respondió 404, devolvemos NOT_FOUND; si ninguna respondió
-        // (fallos de conexión), NODOS_NO_DISPONIBLES.
-        if (any404)
-            return "{\"ok\":false,\"error\":\"NOT_FOUND\"}";
-        return "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}";
+        // Si llegamos aquí, ninguna réplica respondió 200
+        String errorBody;
+        if (any404) {
+            errorBody = "{\"ok\":false,\"error\":\"NOT_FOUND\"}";
+        } else {
+            errorBody = "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}";
+        }
+        System.out.printf("[Failover] Todas las réplicas fallaron para cuenta %d (intentos: %d)%n",
+                accountId, replicaIndex);
+        return new ForwardResult(errorBody, replicaIndex > 0, replicaIndex);
+    }
+
+    // Versión legacy para compatibilidad
+    public static String forwardQuery(List<NodeInfo> replicas, int accountId) {
+        return forwardQueryWithMetrics(replicas, accountId).body;
     }
 
     /**
-     * Reenvía transferencia al nodo primario de la partición del origen.
-     * Solo intenta el primario (no reintentos en réplicas para escrituras).
-     * Retorna el cuerpo de la respuesta o un JSON de error.
+     * Reenvía transferencia con failover inteligente:
+     * - Reintentar en réplicas SOLO si hay fallo de red/timeout (IOException, InterruptedException)
+     * - NO reintentar si el nodo responde con error de negocio (400, 404, 409)
+     * - Retorna resultado con información de failover
+     */
+    public static ForwardResult forwardTransferWithFailover(List<NodeInfo> replicas, int origen, int destino, double monto, String txId) {
+        int replicaIndex = 0;
+        
+        for (NodeInfo node : replicas) {
+            String url = String.format("http://%s:%d/transferir_cuenta?origen=%d&destino=%d&monto=%.2f&txId=%s",
+                    node.getHost(), node.getPort(), origen, destino, monto, txId);
+
+            try {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .timeout(Duration.ofMillis(1300))
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build();
+
+                long start = System.currentTimeMillis();
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                long duration = System.currentTimeMillis() - start;
+                int code = response.statusCode();
+
+                // Errores de negocio: NO reintentar (la operación llegó al nodo)
+                if (code == 400 || code == 404 || code == 409) {
+                    System.out.printf("[Forwarder] Transfer txId=%s → nodo %s respondió %d (error de negocio, no reintentar) en %dms%n",
+                            txId, node, code, duration);
+                    return new ForwardResult(response.body(), replicaIndex > 0, replicaIndex);
+                }
+
+                // Errores 5xx: reintentar en siguiente réplica
+                if (code >= 500 && code < 600) {
+                    System.out.printf("[Failover] Transfer txId=%s → nodo %s respondió %d (error servidor), probando siguiente réplica%n",
+                            txId, node, code);
+                    replicaIndex++;
+                    continue;
+                }
+
+                // Éxito (200) o cualquier otro código
+                if (replicaIndex > 0) {
+                    System.out.printf("[Failover] ✓ Transfer txId=%s completada por réplica %d (%s) con código %d en %dms%n",
+                            txId, replicaIndex, node, code, duration);
+                } else {
+                    System.out.printf("[Forwarder] Transfer txId=%s → nodo primario %s respondió %d en %dms%n",
+                            txId, node, code, duration);
+                }
+                return new ForwardResult(response.body(), replicaIndex > 0, replicaIndex);
+
+            } catch (IOException | InterruptedException e) {
+                // Fallo de red/timeout: SÍ reintentar (la operación NO llegó al nodo)
+                System.out.printf("[Failover] Transfer txId=%s falló en nodo %s (%s: %s), probando siguiente réplica%n",
+                        txId, node, e.getClass().getSimpleName(), e.getMessage());
+                replicaIndex++;
+            }
+        }
+
+        // Todas las réplicas fallaron
+        System.out.printf("[Failover] Transfer txId=%s falló en todas las réplicas (intentos: %d)%n",
+                txId, replicaIndex);
+        return new ForwardResult("{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}", replicaIndex > 0, replicaIndex);
+    }
+
+    /**
+     * Versión legacy sin failover (solo primario) - mantener para compatibilidad
      */
     public static String forwardTransfer(NodeInfo primary, int origen, int destino, double monto, String txId) {
-        String url = String.format("http://%s:%d/transferir_cuenta?origen=%d&destino=%d&monto=%.2f&txId=%s",
-                primary.getHost(), primary.getPort(), origen, destino, monto, txId);
-
-        try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .timeout(Duration.ofMillis(1300))
-                    .POST(HttpRequest.BodyPublishers.noBody())
-                    .build();
-
-            long start = System.currentTimeMillis();
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            long duration = System.currentTimeMillis() - start;
-            int code = response.statusCode();
-
-            System.out.printf("[Forwarder] Transfer txId=%s → nodo %s respondió %d en %dms%n",
-                    txId, primary, code, duration);
-
-            // Retornamos el body tal cual (puede ser 200, 404, 409, 400, etc.)
-            return response.body();
-
-        } catch (IOException | InterruptedException e) {
-            System.out.printf("[Forwarder] Transfer txId=%s falló en nodo %s (%s)%n",
-                    txId, primary, e.getClass().getSimpleName());
-            return "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}";
-        }
+        List<NodeInfo> singleNode = List.of(primary);
+        return forwardTransferWithFailover(singleNode, origen, destino, monto, txId).body;
     }
 
     /**
-     * Reenvía consulta de estado de préstamo a las réplicas en orden de prioridad.
+     * Reenvía consulta de estado de préstamo con failover completo.
      * Intenta primario → réplica1 → réplica2 hasta recibir 200.
-     * Diferencia entre 404 (cuenta sin préstamos o no existe) y fallos de conexión.
+     * Diferencia entre 404 (cuenta sin préstamos) y fallos de conexión/5xx.
      */
-    public static String forwardPrestamo(List<NodeInfo> replicas, int cuentaId) {
+    public static ForwardResult forwardPrestamoWithMetrics(List<NodeInfo> replicas, int cuentaId) {
         boolean any404 = false;
+        int replicaIndex = 0;
+        
         for (NodeInfo node : replicas) {
             String url = String.format("http://%s:%d/estado_prestamo?id=%d",
                     node.getHost(), node.getPort(), cuentaId);
@@ -129,29 +210,57 @@ public class WorkerForwarder {
                 int code = response.statusCode();
 
                 if (code == 200) {
-                    System.out.printf("[Forwarder] Prestamo id=%d → nodo %s respondió %d en %dms%n",
-                            cuentaId, node, code, duration);
-                    return response.body();
+                    if (replicaIndex > 0) {
+                        System.out.printf("[Failover] ✓ Prestamo id=%d respondido por réplica %d (%s) en %dms%n",
+                                cuentaId, replicaIndex, node, duration);
+                    } else {
+                        System.out.printf("[Forwarder] Prestamo id=%d → nodo primario %s respondió %d en %dms%n",
+                                cuentaId, node, code, duration);
+                    }
+                    return new ForwardResult(response.body(), replicaIndex > 0, replicaIndex);
                 }
 
                 if (code == 404) {
-                    System.out.printf("[Forwarder] Prestamo id=%d → nodo %s respondió 404, probando siguiente%n",
+                    System.out.printf("[Forwarder] Prestamo id=%d → nodo %s respondió 404, probando siguiente réplica%n",
                             cuentaId, node);
                     any404 = true;
+                    replicaIndex++;
                     continue;
                 }
 
-                System.out.printf("[Forwarder] Prestamo id=%d → nodo %s devolvió código %d%n",
+                // Errores 5xx: reintentar en siguiente réplica
+                if (code >= 500 && code < 600) {
+                    System.out.printf("[Failover] Prestamo id=%d → nodo %s respondió %d (error servidor), probando siguiente réplica%n",
+                            cuentaId, node, code);
+                    replicaIndex++;
+                    continue;
+                }
+
+                System.out.printf("[Forwarder] Prestamo id=%d → nodo %s devolvió código %d (no reintentar)%n",
                         cuentaId, node, code);
+                return new ForwardResult(response.body(), replicaIndex > 0, replicaIndex);
 
             } catch (IOException | InterruptedException e) {
-                System.out.printf("[Forwarder] Prestamo id=%d falló en nodo %s (%s)%n",
-                        cuentaId, node, e.getClass().getSimpleName());
+                System.out.printf("[Failover] Prestamo id=%d falló en nodo %s (%s: %s), probando siguiente réplica%n",
+                        cuentaId, node, e.getClass().getSimpleName(), e.getMessage());
+                replicaIndex++;
             }
         }
 
-        if (any404)
-            return "{\"ok\":false,\"error\":\"CUENTA_SIN_PRESTAMOS\"}";
-        return "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}";
+        // Todas las réplicas fallaron
+        String errorBody;
+        if (any404) {
+            errorBody = "{\"ok\":false,\"error\":\"CUENTA_SIN_PRESTAMOS\"}";
+        } else {
+            errorBody = "{\"ok\":false,\"error\":\"NODOS_NO_DISPONIBLES\"}";
+        }
+        System.out.printf("[Failover] Prestamo id=%d falló en todas las réplicas (intentos: %d)%n",
+                cuentaId, replicaIndex);
+        return new ForwardResult(errorBody, replicaIndex > 0, replicaIndex);
+    }
+
+    // Versión legacy para compatibilidad
+    public static String forwardPrestamo(List<NodeInfo> replicas, int cuentaId) {
+        return forwardPrestamoWithMetrics(replicas, cuentaId).body;
     }
 }


### PR DESCRIPTION

- Agregar clase ForwardResult para rastrear métricas de failover
- Implementar reintentos automáticos en réplicas secundarias para timeouts, errores de conexión y respuestas 5xx
- Agregar failover inteligente para transferencias (reintentar solo en fallos de red, no en errores de negocio 400/404/409)
- Mejorar logging con indicadores [Failover]  mostrando qué réplica respondió
- Agregar try/catch para NumberFormatException en todos los handlers (retornar 400 en lugar de 500)
- Corregir contador fallbacksTotal para incrementar correctamente al usar réplicas secundarias