### PR TITLE
Agregar endpoint verify-replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,59 @@ java BankCli.java consultar 42 --coordinator=localhost:8080
     `POST http://localhost:8080/crear_prestamo?idCliente=42&monto=1000.00&tasaAnual=0.25&loanId=loan-001`
   - Respuesta: `{"ok":true,"idPrestamo":1}` o `{"ok":false,"error":"CLIENTE_NO_EXISTE"}`
 
+#### Mantenimiento y Verificación
+- **POST /verify_replica?id=ID**
+  - Verifica la consistencia de una cuenta entre todas sus réplicas y repara automáticamente si encuentra inconsistencias.
+  - Parámetros: `id` (ID de la cuenta a verificar)
+  - Proceso:
+    1. Calcula la partición de la cuenta
+    2. Obtiene todas las réplicas registradas para esa partición
+    3. Verifica la consistencia de los datos entre réplicas usando `AccountVerifier`
+    4. Si detecta inconsistencias, ejecuta reparación automática usando `AccountRepairer`
+  - Ejemplo:
+    `POST http://localhost:8080/verify_replica?id=42`
+  - Respuestas:
+    - **Consistente (sin reparación necesaria)**:
+      ```json
+      {
+        "ok": true,
+        "verify": {
+          "consistent": true,
+          "replicas_checked": 3,
+          "primary_data": {"id":42,"saldo":"1000.00",...}
+        }
+      }
+      ```
+    - **Inconsistente (con reparación exitosa)**:
+      ```json
+      {
+        "ok": true,
+        "verify": {
+          "consistent": false,
+          "replicas_checked": 3,
+          "inconsistencies": ["nodeB: saldo mismatch", "nodeC: missing record"]
+        },
+        "repair": {
+          "success": true,
+          "repaired_nodes": ["nodeB", "nodeC"],
+          "source": "nodeA"
+        }
+      }
+      ```
+    - **Error (sin réplicas disponibles)**:
+      ```json
+      {
+        "ok": false,
+        "error": "NODOS_NO_REGISTRADOS",
+        "msg": "No hay réplicas registradas para la partición 1",
+        "partition": 1
+      }
+      ```
+  - **Uso desde CLI**:
+    ```powershell
+    java BankCli.java verify-replica 42 --coordinator=localhost:8080
+    ```
+
 #### Monitoreo
 - **GET /routing**
   - Devuelve el mapeo actual de particiones y nodos registrados.

--- a/src/main/java/cc4p1/clients/cli/BankCli.java
+++ b/src/main/java/cc4p1/clients/cli/BankCli.java
@@ -328,6 +328,47 @@ public final class BankCli {
                     System.exit(4);
                 }
             }
+            case "verify-replica" -> {
+                if (args.length < 2) {
+                    System.err.println("Uso: verify-replica <id> --coordinator=host:port");
+                    System.exit(2);
+                }
+                String coord = null;
+                String idStr = null;
+                for (int i = 1; i < args.length; i++) {
+                    String a = args[i];
+                    if (a.startsWith("--coordinator=")) {
+                        coord = a.substring("--coordinator=".length());
+                        continue;
+                    }
+                    if (!a.startsWith("--") && idStr == null)
+                        idStr = a;
+                }
+                if (coord == null || idStr == null) {
+                    System.err.println("Faltan argumentos. Uso: verify-replica <id> --coordinator=host:port");
+                    System.exit(2);
+                }
+                long id;
+                try {
+                    id = Long.parseLong(idStr);
+                } catch (NumberFormatException nfe) {
+                    System.err.println("id inválido");
+                    System.exit(2);
+                    return;
+                }
+                String url = String.format("http://%s/verify_replica?id=%d", coord, id);
+                HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofMillis(1000)).build();
+                HttpRequest req = HttpRequest.newBuilder().POST(HttpRequest.BodyPublishers.noBody())
+                        .uri(URI.create(url)).timeout(Duration.ofSeconds(5)).build();
+                try {
+                    HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                    System.out.println(resp.body());
+                    System.exit(resp.statusCode() == 200 ? 0 : 5);
+                } catch (IOException | InterruptedException e) {
+                    System.err.println("Error verificando réplica: " + e.getMessage());
+                    System.exit(4);
+                }
+            }
             default -> {
                 System.err.println("Comando desconocido: " + cmd);
                 usage();
@@ -344,6 +385,7 @@ public final class BankCli {
                 "\n  prestamo-crear <idCliente> <monto> [--tasa=0.25] --coordinator=host:port [--loanid=ID]" +
                 "\n  prestamo-estado <idCuenta> --coordinator=host:port" +
                 "\n  consultar-transacciones <idCuenta> --coordinator=host:port" +
+                "\n  verify-replica <id> --coordinator=host:port" +
                 "\n  loadgen --coordinator=host:port --threads=N --durationSec=S --ops=transfer|loan|mixed --rate=Rps --min=MIN --max=MAX --delayMsMin=A --delayMsMax=B --out=results.csv [--from=ID --to=ID | --accountRange=MIN:MAX]");
     }
 }

--- a/src/main/java/cc4p1/coordinator/CoordinatorServer.java
+++ b/src/main/java/cc4p1/coordinator/CoordinatorServer.java
@@ -22,6 +22,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import cc4p1.storage.Partitioner;
 import java.util.concurrent.Executors;
+import cc4p1.coordinator.maintenance.AccountVerifier;
+import cc4p1.coordinator.maintenance.AccountRepairer;
+import cc4p1.coordinator.maintenance.VerifyResult;
+import cc4p1.coordinator.maintenance.RepairResult;
 
 public class CoordinatorServer {
 
@@ -49,6 +53,7 @@ public class CoordinatorServer {
         server.createContext("/routing", new RoutingHandler());
         server.createContext("/healthz", new HealthHandler());
         server.createContext("/metrics", new MetricsHandler());
+        server.createContext("/verify_replica", new VerifyReplicaHandler());
         server.setExecutor(Executors.newCachedThreadPool());
         server.start();
 
@@ -88,10 +93,12 @@ public class CoordinatorServer {
                 }
                 sb.append(']');
             }
-            sb.append("}});");
+            // FIX: remove stray characters that broke JSON ("});")
+            sb.append("}}");
             sendResponse(exchange, 200, sb.toString());
         }
     }
+// ...existing code...
 
     // --- Handlers ---
 
@@ -475,6 +482,67 @@ public class CoordinatorServer {
                     "{\"ok\":true,\"metrics\":{\"req_total\":%d,\"fallbacks_total\":%d,\"errors_total\":%d}}",
                     reqTotal.get(), fallbacksTotal.get(), errorsTotal.get());
             sendResponse(exchange, 200, response);
+        }
+    }
+
+    static class VerifyReplicaHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange ex) throws IOException {
+            if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) {
+                sendResponse(ex, 405, "{\"ok\":false,\"error\":\"Método no permitido\"}");
+                return;
+            }
+
+            Map<String,String> q = parseQuery(ex.getRequestURI());
+            String idStr = q.get("id");
+            if (idStr == null || idStr.isBlank()) {
+                sendResponse(ex, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"Falta parámetro id\"}");
+                return;
+            }
+
+            try {
+                long id = Long.parseLong(idStr.trim());
+                // partitioner expects int partitions in the rest of the code; cast explicitly
+                int partition = PARTITIONER.partForId((int) id);
+
+                List<NodeInfo> replicas = routingTable.getReplicas(partition);
+                // Defensive: routingTable may return null for unregistered partitions
+                if (replicas == null || replicas.isEmpty()) {
+                    String snap = String.valueOf(routingTable.snapshot());
+                    String body = String.format(
+                        "{\"ok\":false,\"error\":\"NODOS_NO_REGISTRADOS\",\"msg\":\"No hay réplicas registradas para la partición %d\",\"partition\":%d,\"routing_snapshot\":\"%s\"}",
+                        partition, partition, snap.replace("\"", "\\\""));
+                    System.err.println("[Coordinator] VerifyReplicaHandler: " + body);
+                    sendResponse(ex, 503, body);
+                    return;
+                }
+
+                // Verify consistency and possibly repair
+                AccountVerifier verifier = new AccountVerifier(replicas);
+                VerifyResult result = verifier.verify(id);
+
+                RepairResult repairResult = null;
+                if (result.needsRepair()) {
+                    AccountRepairer repairer = new AccountRepairer();
+                    repairResult = repairer.repair(result, id);
+                }
+
+                StringBuilder response = new StringBuilder();
+                response.append("{\"ok\":true,");
+                response.append("\"verify\":").append(result.toJson());
+                if (repairResult != null) {
+                    response.append(",\"repair\":").append(repairResult.toJson());
+                }
+                response.append("}");
+                sendResponse(ex, 200, response.toString());
+
+            } catch (NumberFormatException e) {
+                sendResponse(ex, 400, "{\"ok\":false,\"error\":\"VALIDACION\",\"msg\":\"id inválido\"}");
+            } catch (Exception e) {
+                errorsTotal.incrementAndGet();
+                System.err.println("[Coordinator] VerifyReplicaHandler ERROR: " + e.getMessage());
+                sendResponse(ex, 500, "{\"ok\":false,\"error\":\"INTERNAL\",\"msg\":\"" + e.getMessage() + "\"}");
+            }
         }
     }
 

--- a/src/main/java/cc4p1/coordinator/maintenance/AccountRepairer.java
+++ b/src/main/java/cc4p1/coordinator/maintenance/AccountRepairer.java
@@ -1,0 +1,79 @@
+package cc4p1.coordinator.maintenance;
+
+import cc4p1.coordinator.NodeInfo;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.*;
+
+/**
+ * Repara réplicas inconsistentes copiando los datos desde un nodo correcto.
+ */
+public class AccountRepairer {
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofMillis(500))
+            .build();
+
+    public RepairResult repair(VerifyResult verifyResult, long accountId) {
+        if (!verifyResult.needsRepair()) {
+            return new RepairResult(true, null, Collections.emptyList());
+        }
+
+        List<NodeInfo> repairedNodes = new ArrayList<>();
+        String error = null;
+
+        // Obtener datos fuente del primer nodo de la mayoría
+        NodeInfo sourceNode = verifyResult.getMajorityNode();
+        String sourceData = fetchAccountData(sourceNode, accountId);
+        
+        if (sourceData == null) {
+            return new RepairResult(false, "No se pudo obtener los datos fuente", Collections.emptyList());
+        }
+
+        // Copiar a todos los nodos outliers e inalcanzables
+        List<NodeInfo> toRepair = new ArrayList<>();
+        toRepair.addAll(verifyResult.getOutliers());
+        toRepair.addAll(verifyResult.getUnreachable());
+
+        for (NodeInfo node : toRepair) {
+            try {
+                // Usar PUT para forzar la actualización
+                String url = String.format("http://%s:%d/admin/repair_account?id=%d",
+                        node.getHost(), node.getPort(), accountId);
+                HttpRequest req = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .timeout(Duration.ofSeconds(1))
+                        .header("Content-Type", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(sourceData))
+                        .build();
+                HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() == 200) {
+                    repairedNodes.add(node);
+                }
+            } catch (Exception e) {
+                // Continuar con otros nodos
+            }
+        }
+
+        boolean success = repairedNodes.size() == toRepair.size();
+        return new RepairResult(success, error, repairedNodes);
+    }
+
+    private String fetchAccountData(NodeInfo node, long accountId) {
+        try {
+            String url = String.format("http://%s:%d/consultar_cuenta?id=%d",
+                    node.getHost(), node.getPort(), accountId);
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofMillis(800))
+                    .GET()
+                    .build();
+            HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+            return resp.statusCode() == 200 ? resp.body() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/cc4p1/coordinator/maintenance/AccountVerifier.java
+++ b/src/main/java/cc4p1/coordinator/maintenance/AccountVerifier.java
@@ -1,0 +1,90 @@
+package cc4p1.coordinator.maintenance;
+
+import cc4p1.coordinator.NodeInfo;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.*;
+
+public class AccountVerifier {
+    private final List<NodeInfo> replicas;
+    private final HttpClient client;
+
+    public AccountVerifier(List<NodeInfo> replicas) {
+        this.replicas = new ArrayList<>(replicas);
+        this.client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(500))
+                .build();
+    }
+
+    public VerifyResult verify(long accountId) {
+        Map<String, List<NodeInfo>> checksums = new HashMap<>();
+        List<NodeInfo> unreachable = new ArrayList<>();
+
+        // ADD DEBUG: Track what we're checking
+        System.err.printf("[AccountVerifier] Checking account %d across %d replicas%n", 
+                         accountId, replicas.size());
+
+        for (NodeInfo node : replicas) {
+            try {
+                String url = String.format("http://%s:%d/consultar_cuenta?id=%d",
+                        node.getHost(), node.getPort(), accountId);
+                
+                System.err.printf("[AccountVerifier] Querying: %s%n", url);
+                
+                HttpRequest req = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .timeout(Duration.ofMillis(800))
+                        .GET()
+                        .build();
+                HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                
+                System.err.printf("[AccountVerifier] Node %s:%d returned status=%d, body=%s%n",
+                                 node.getHost(), node.getPort(), resp.statusCode(), 
+                                 resp.body().substring(0, Math.min(100, resp.body().length())));
+                
+                if (resp.statusCode() == 200) {
+                    String body = resp.body();
+                    checksums.computeIfAbsent(body, k -> new ArrayList<>()).add(node);
+                } else {
+                    System.err.printf("[AccountVerifier] Non-200 status, marking unreachable%n");
+                    unreachable.add(node);
+                }
+            } catch (Exception e) {
+                System.err.printf("[AccountVerifier] Exception for node %s:%d - %s%n",
+                                 node.getHost(), node.getPort(), e.getMessage());
+                unreachable.add(node);
+            }
+        }
+
+        System.err.printf("[AccountVerifier] Results: %d unique checksums, %d unreachable%n",
+                         checksums.size(), unreachable.size());
+
+        // Find majority response (2+ nodes with same data)
+        String majorityChecksum = null;
+        List<NodeInfo> majorityNodes = Collections.emptyList();
+        List<NodeInfo> outliers = new ArrayList<>();
+
+        for (Map.Entry<String, List<NodeInfo>> entry : checksums.entrySet()) {
+            System.err.printf("[AccountVerifier] Checksum group: %d nodes%n", entry.getValue().size());
+            if (entry.getValue().size() >= 2) {
+                majorityChecksum = entry.getKey();
+                majorityNodes = entry.getValue();
+                break;
+            }
+        }
+
+        if (majorityChecksum != null) {
+            for (NodeInfo node : replicas) {
+                if (!majorityNodes.contains(node) && !unreachable.contains(node)) {
+                    outliers.add(node);
+                }
+            }
+        }
+
+        return new VerifyResult(majorityChecksum != null, majorityChecksum, 
+                              majorityNodes, outliers, unreachable);
+    }
+}

--- a/src/main/java/cc4p1/coordinator/maintenance/RepairResult.java
+++ b/src/main/java/cc4p1/coordinator/maintenance/RepairResult.java
@@ -1,0 +1,38 @@
+package cc4p1.coordinator.maintenance;
+
+import cc4p1.coordinator.NodeInfo;
+import java.util.List;
+
+/**
+ * Resultado de la operación de reparación de réplicas.
+ */
+public class RepairResult {
+    private final boolean success;
+    private final String error;
+    private final List<NodeInfo> repairedNodes;
+
+    public RepairResult(boolean success, String error, List<NodeInfo> repairedNodes) {
+        this.success = success;
+        this.error = error;
+        this.repairedNodes = repairedNodes;
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"success\":").append(success);
+        if (error != null) {
+            sb.append(",\"error\":\"").append(error.replace("\"", "\\\"")).append("\"");
+        }
+        sb.append(",\"repairedNodes\":[");
+        boolean first = true;
+        for (NodeInfo node : repairedNodes) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{\"host\":\"").append(node.getHost())
+              .append("\",\"port\":").append(node.getPort()).append("}");
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/cc4p1/coordinator/maintenance/VerifyResult.java
+++ b/src/main/java/cc4p1/coordinator/maintenance/VerifyResult.java
@@ -1,0 +1,65 @@
+package cc4p1.coordinator.maintenance;
+
+import cc4p1.coordinator.NodeInfo;
+import java.util.List;
+
+public class VerifyResult {
+    private final boolean hasMajority;
+    private final String majorityChecksum;
+    private final List<NodeInfo> majority;
+    private final List<NodeInfo> outliers;
+    private final List<NodeInfo> unreachable;
+
+    public VerifyResult(boolean hasMajority, String majorityChecksum,
+                       List<NodeInfo> majority, List<NodeInfo> outliers,
+                       List<NodeInfo> unreachable) {
+        this.hasMajority = hasMajority;
+        this.majorityChecksum = majorityChecksum;
+        this.majority = majority;
+        this.outliers = outliers;
+        this.unreachable = unreachable;
+    }
+
+    public boolean needsRepair() {
+        return hasMajority && (!outliers.isEmpty() || !unreachable.isEmpty());
+    }
+
+    // Add these getter methods
+    public NodeInfo getMajorityNode() {
+        return majority != null && !majority.isEmpty() ? majority.get(0) : null;
+    }
+
+    public List<NodeInfo> getOutliers() {
+        return outliers;
+    }
+
+    public List<NodeInfo> getUnreachable() {
+        return unreachable;
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"hasMajority\":").append(hasMajority);
+        if (majorityChecksum != null) {
+            sb.append(",\"majorityChecksum\":\"").append(majorityChecksum.replace("\"", "\\\"")).append("\"");
+        }
+        appendNodeList(sb, "majority", majority);
+        appendNodeList(sb, "outliers", outliers);
+        appendNodeList(sb, "unreachable", unreachable);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private void appendNodeList(StringBuilder sb, String name, List<NodeInfo> nodes) {
+        sb.append(",\"").append(name).append("\":[");
+        boolean first = true;
+        for (NodeInfo node : nodes) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{\"host\":\"").append(node.getHost())
+              .append("\",\"port\":").append(node.getPort()).append("}");
+        }
+        sb.append("]");
+    }
+}


### PR DESCRIPTION
Agregra endpoint verify-replica en BankCli y CoordinatorServer para
 verificar la integridad de una réplica específica.
Implementar la lógica de verificación en AccountVerifier y
 exponerla a través del CLI.